### PR TITLE
Addition of P.C. 8022

### DIFF
--- a/penal-code.ts
+++ b/penal-code.ts
@@ -1215,7 +1215,15 @@ const PenalCode: PenalCode[] = [
         months: 5,
         fine: 1500,
         description: "A licensed person who fails to report a lost or stolen firearm; lends a firearm to another licensed person outside the presence of the registered owner; or provides firearm access to an unlicensed person is guilty under this code section.",
-      },      
+      },
+      22: {
+        title: "Criminal Possession of Ammunition",
+        class: "Felony",
+        id: 8022,
+        months: 5,
+        fine: 500,
+        description: "A person who possesses ammunition without a firearms license, or who is otherwise legally prohibited from possessing ammunition due to their criminal history, is guilty under this code section.",
+      },
     },
   },
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new statute under Offenses Against Public Safety: “Criminal Possession of Ammunition.” Classified as a felony with penalties of up to 5 months incarceration and a $500 fine. Applies to possession of ammunition without a firearms license or by individuals otherwise prohibited due to criminal history. The statute now appears in the section’s list for charging and reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->